### PR TITLE
Fix error C2561 when using PlatformToolset v100.

### DIFF
--- a/virtools/CKDef.h
+++ b/virtools/CKDef.h
@@ -4,7 +4,7 @@
 
 #define VX_EXPORT
 #define NAKED __declspec(naked)
-#define UNDEFINED throw "Unimplemented function called."
+#define UNDEFINED throw "Unimplemented function called.";__asm ret
 
 #include "../Export.h"
 #include "VxMathDefines.h"


### PR DESCRIPTION
I changed the defination of UNDEFINED. I add a fake `__asm ret` to trick compiler to get a successful build. It seems that PlatformToolset v100 doesn't understand the code following throw is unreachable. So it throw error C2561.
Recently I am using Visual Studio 2010 Toolset(v100) to build some project, and the compiler throw C2561 error when I use this reversed Virtools SDK. So I made this patch to fix this error. This patch is harmless. It never change original functions. The only thing what this patch do is trick old compiler. The patched reversed Virtools can be compiled with v100(VS2010) or v142(VS2019) and no runtime error during program running. So, everything is not changed, why not to support more platform?

我改变了 UNDEFINED 的定义。 添加了一个假的 `__asm ret` 来欺骗编译器以获得成功的构建。 似乎使用 PlatformToolset v100 无法正确识别 throw 之后的代码是无法访问的。 所以它抛出错误 C2561。
最近我正在使用 Visual Studio 2010 Toolset(v100) 来构建一些项目，当我使用这个反向 Virtools SDK 时，编译器抛出 C2561 错误。所以我做了这个补丁来修复这个错误。 这个补丁是无害的。 它永远不会改变原始功能。 这个补丁唯一能做的就是欺骗旧的编译器。打过补丁的逆向 Virtools SDK 用 v100(VS2010) 或 v142(VS2019) 都可以编译成功，运行起来也没有什么错误。没有什么会改变，我觉得让它多支持一个编译平台又何尝不可？

当然，最后做决定的是还是你。如果是我忘开了什么编译器选项导致了这个错误还请多多指教（我太菜了）。