### PR TITLE
Fix for 3 bugs in previous versions found by communities

### DIFF
--- a/BuildVer.h
+++ b/BuildVer.h
@@ -1,3 +1,3 @@
 #define BML_MAJOR_VER 0
 #define BML_MINOR_VER 3
-#define BML_BUILD_VER 41
+#define BML_BUILD_VER 42

--- a/ModLoader.cpp
+++ b/ModLoader.cpp
@@ -30,6 +30,11 @@ std::vector<std::string> SplitString(const std::string& str, const std::string& 
 	return res;
 }
 
+void ToLower(std::string& data) {
+	std::transform(data.begin(), data.end(), data.begin(),
+								 [](unsigned char c) { return std::tolower(c); });
+}
+
 bool StartWith(const std::string& str, const std::string& start) {
 	return str.substr(0, start.size()) == start;
 }
@@ -373,7 +378,7 @@ void ModLoader::Process(CKERROR result) {
 	}
 
 	BroadcastCallback(&IMod::OnProcess, &IMod::OnProcess);
-	if (m_inputManager->IsKeyDown(CKKEY_F))
+	if (m_inputManager->IsKeyDown(CKKEY_F) && IsCheatEnabled())
 		SkipRenderForNextTick();
 
 	m_inputManager->Process();
@@ -701,6 +706,7 @@ ICommand* ModLoader::FindCommand(const std::string& name) {
 void ModLoader::ExecuteCommand(CKSTRING cmd) {
 	m_logger->Info("Execute Command: %s", cmd);
 	std::vector<std::string> args = SplitString(cmd, " ");
+	ToLower(args[0]);
 	ICommand* command = FindCommand(args[0]);
 	if (command) command->Execute(this, args);
 	else m_bmlmod->AddIngameMessage(("Error: Unknown Command " + args[0]).c_str());


### PR DESCRIPTION
- Suppress messages of ball speed changes if all new speeds remain the same with old ones
    - This also fixed the related bug in 0.3.41 where every cheat toggle gives a message alerting ball speed changes
- Make skips of rendering by pressing `F` only possible when cheat mode is enabled
    - The proximity of `F` to `W` `A` `S` `D` and various shortcut keys makes it especially easy to be mistakenly pressed during normal gaming and can be problematic with speedruns and online matches
- Auto-lowercase for the first word of command (i.e., made the command case-insensitive)