### PR TITLE
Features: option to disable the suicide/reset key and command to toggle watermark

### DIFF
--- a/BMLMod.cpp
+++ b/BMLMod.cpp
@@ -613,6 +613,10 @@ void BMLMod::OnLoad() {
 	m_customMapNumber->SetDefaultInteger(0);
 
 	GetConfig()->SetCategoryComment("Debug", "Debug Utilities");
+	m_suicideOn = GetConfig()->GetProperty("Debug", "EnableSuicideKey");
+	m_suicideOn->SetComment("Enable the Suicide Hotkey.");
+	m_suicideOn->SetDefaultBoolean(true);
+
 	m_suicide = GetConfig()->GetProperty("Debug", "Suicide");
 	m_suicide->SetComment("Suicide");
 	m_suicide->SetDefaultKey(CKKEY_R);
@@ -814,7 +818,7 @@ void BMLMod::OnProcess() {
 
 	if (m_bml->IsPlaying()) {
 		if (!m_suicideCd) {
-			if (m_bml->IsPlaying() && im->IsKeyPressed(m_suicide->GetKey())) {
+			if (m_suicideOn->GetBoolean() && im->IsKeyPressed(m_suicide->GetKey())) {
 				ModLoader::m_instance->ExecuteCommand("kill");
 				m_suicideCd = true;
 				m_bml->AddTimer(1000.0f, [this]() { m_suicideCd = false; });

--- a/BMLMod.cpp
+++ b/BMLMod.cpp
@@ -48,7 +48,7 @@ void BMLMod::OnLoadObject(CKSTRING filename, BOOL isMap, CKSTRING masterName, CK
 
 		GetLogger()->Info("Create BML Gui");
 		m_ingameBanner = new BGui::Gui();
-		m_ingameBanner->AddTextLabel("M_Use_BML", "Ballance Mod Loader " BML_VERSION, ExecuteBB::GAMEFONT_01, 0, 0, 1, 0.03f);
+		m_watermark = m_ingameBanner->AddTextLabel("M_Use_BML", "Ballance Mod Loader " BML_VERSION, ExecuteBB::GAMEFONT_01, 0, 0, 1, 0.03f);
 		m_cheat = m_ingameBanner->AddTextLabel("M_Use_Cheat", "Cheat Mode Enabled", ExecuteBB::GAMEFONT_01, 0, 0.85f, 1, 0.05f);
 		//m_cheat[1] = m_ingameBanner->AddTextLabel("M_Use_Cheat", "Cheat Mode Enabled", ExecuteBB::GAMEFONT_03A, 0.001f, 0.901f, 1, 0.03f);
 		//m_cheat[2] = m_ingameBanner->AddTextLabel("M_Use_Cheat", "Cheat Mode Enabled", ExecuteBB::GAMEFONT_03A, 0.002f, 0.902f, 1, 0.03f);
@@ -736,6 +736,7 @@ void BMLMod::OnLoad() {
 	m_bml->RegisterCommand(new CommandKill());
 	m_bml->RegisterCommand(new CommandSetSpawn());
 	m_bml->RegisterCommand(new CommandSector());
+	m_bml->RegisterCommand(new CommandWatermark());
 	m_bml->RegisterCommand(new CommandWin());
 	m_bml->RegisterCommand(new CommandTravel(this));
 
@@ -1157,6 +1158,10 @@ void BMLMod::ShowCheatBanner(bool show) {
 	m_cheat->SetVisible(show);
 }
 
+void BMLMod::ShowWatermark(bool show) {
+	m_watermark->SetVisible(show);
+}
+
 void BMLMod::ShowModOptions() {
 	ShowGui(m_modOption);
 	m_modOption->SetPage(0);
@@ -1175,6 +1180,10 @@ void BMLMod::ShowGui(BGui::Gui* gui) {
 void BMLMod::CloseCurrentGui() {
 	m_currentGui->SetVisible(false);
 	m_currentGui = nullptr;
+}
+
+bool BMLMod::IsWatermarkEnabled() {
+	return m_watermark->IsVisible();
 }
 
 void BMLMod::EnterTravelCam() {

--- a/BMLMod.h
+++ b/BMLMod.h
@@ -237,7 +237,7 @@ private:
 	IProperty* m_customMapNumber;
 
 	IProperty* m_ballCheat[2];
-	IProperty* m_suicide;
+	IProperty* m_suicide, * m_suicideOn;
 	CKParameterLocal* m_ballForce[2] = { 0 };
 	bool m_suicideCd = false;
 

--- a/BMLMod.h
+++ b/BMLMod.h
@@ -179,9 +179,11 @@ public:
 
 	void AddIngameMessage(CKSTRING msg);
 	void ShowCheatBanner(bool show);
+	void ShowWatermark(bool show);
 	void ShowModOptions();
 	void ShowGui(BGui::Gui* gui);
 	void CloseCurrentGui();
+	bool IsWatermarkEnabled();
 
 	float GetSRScore() { return m_srtimer; }
 	int GetHSScore();
@@ -218,7 +220,7 @@ private:
 	} m_msg[MSG_MAXSIZE];
 
 	BGui::Gui* m_ingameBanner = nullptr;
-	BGui::Label* m_cheat, * m_fps, * m_srScore, * m_srTitle = nullptr;
+	BGui::Label* m_watermark, * m_cheat, * m_fps, * m_srScore, * m_srTitle = nullptr;
 	int m_fpscnt = 0, m_fpstimer = 0;
 	float m_srtimer = 0.0f;
 	bool m_sractive = false;

--- a/BuildVer.h
+++ b/BuildVer.h
@@ -1,3 +1,3 @@
 #define BML_MAJOR_VER 0
 #define BML_MINOR_VER 3
-#define BML_BUILD_VER 42
+#define BML_BUILD_VER 43

--- a/Commands.cpp
+++ b/Commands.cpp
@@ -273,6 +273,17 @@ void CommandSector::ResetBall(IBML* bml, CKContext* ctx) {
 		});
 }
 
+void CommandWatermark::Execute(IBML* bml, const std::vector<std::string>& args) {
+	BMLMod* mod = ModLoader::m_instance->m_bmlmod;
+	if (args.size() == 1) {
+		mod->ShowWatermark(!mod->IsWatermarkEnabled());
+	}
+	else {
+		mod->ShowWatermark(ParseBoolean(args[1]));
+	}
+	bml->SendIngameMessage(mod->IsWatermarkEnabled() ? "Watermark On" : "Watermark Off");
+}
+
 void CommandWin::Execute(IBML* bml, const std::vector<std::string>& args) {
 	if (bml->IsPlaying()) {
 		CKMessageManager* mm = bml->GetMessageManager();

--- a/Commands.h
+++ b/Commands.h
@@ -120,6 +120,18 @@ private:
 	CKParameter* m_curSector;
 };
 
+class CommandWatermark : public ICommand {
+	virtual std::string GetName() override { return "watermark"; };
+	virtual std::string GetAlias() override { return ""; };
+	virtual std::string GetDescription() override { return "Enable or Disable the BML watermark."; };
+	virtual bool IsCheat() override { return false; };
+
+	virtual void Execute(IBML* bml, const std::vector<std::string>& args) override;
+	virtual const std::vector<std::string> GetTabCompletion(IBML* bml, const std::vector<std::string>& args) override {
+		return args.size() == 2 ? std::vector<std::string>({ "true", "false" }) : std::vector<std::string>();
+	};
+};
+
 class CommandWin : public ICommand {
 	virtual std::string GetName() override { return "win"; };
 	virtual std::string GetAlias() override { return ""; };

--- a/ModLoader.cpp
+++ b/ModLoader.cpp
@@ -636,6 +636,7 @@ void ModLoader::OnPostCheckpointReached() {
 
 void ModLoader::OnLevelFinish() {
 	BroadcastMessage("LevelFinish", &IMod::OnLevelFinish);
+	m_bmlmod->ShowWatermark(true);
 }
 
 void ModLoader::OnGameOver() {

--- a/ModLoader.h
+++ b/ModLoader.h
@@ -32,6 +32,7 @@ class ModLoader : public IBML {
 	friend class CommandCheat;
 	friend class CommandClear;
 	friend class CommandSector;
+	friend class CommandWatermark;
 	friend class GuiList;
 	friend class GuiModOption;
 	friend class GuiModMenu;


### PR DESCRIPTION
**Suicide/Reset Key**:
- This can cause problems during events like online multiplayer matches where, like normal SR records, its usage is not allowed. However, as there were no easy options to disable this feature, players have to resort to setting the key to an obscure one on the keyboard or just trust themselves to not mishit.
- This non-disable-able feature has also been used as an excuse for map creators to not fix their own problems in their maps where player balls may get trapped, as Ballance Mod Loader is now commonplace and its usage is ubiquitous due to compatibility issues with the original/vanilla version.

**Non-Togglable BML Watermark**:
- The original rationale for this was to prevent players from faking records. However, this was only possible on the assumption that all speedrun players can't code - if they can and do intend on faking some, then the watermark won't be of any importance in their detection.
- The Debug Mode Watermark is still visible anyways.
- By now the BML Watermark has been a nuisance for players who want to create Ballance content without any text interferences.

**Some Afterthoughts**: maybe we should rename the *suicide* key to the *reset* key (different from *restart*) as the *suicide* name has some unfortunate connotations and can be misunderstood.