### PR TITLE
More fixes and features requested by the community

### DIFF
--- a/BMLMod.cpp
+++ b/BMLMod.cpp
@@ -628,6 +628,10 @@ void BMLMod::OnLoad() {
 	m_suicideOn->SetComment("Enable the Suicide Hotkey.");
 	m_suicideOn->SetDefaultBoolean(true);
 
+	m_speedNotification = GetConfig()->GetProperty("Debug", "SpeedNotification");
+	m_speedNotification->SetComment("Notify the player when speed of the ball changes.");
+	m_speedNotification->SetDefaultBoolean(true);
+
 	m_suicide = GetConfig()->GetProperty("Debug", "Suicide");
 	m_suicide->SetComment("Suicide");
 	m_suicide->SetDefaultKey(CKKEY_R);
@@ -663,6 +667,10 @@ void BMLMod::OnLoad() {
 	m_speedupBall = GetConfig()->GetProperty("Debug", "BallSpeedUp");
 	m_speedupBall->SetComment("Change to 3 times ball speed");
 	m_speedupBall->SetDefaultKey(CKKEY_LCONTROL);
+
+	ModLoader::m_instance->m_skipRenderKey = GetConfig()->GetProperty("Debug", "SkipRender");
+	ModLoader::m_instance->m_skipRenderKey->SetComment("Skip rendering of current frames while holding.");
+	ModLoader::m_instance->m_skipRenderKey->SetDefaultKey(CKKEY_F);
 
 	GetConfig()->SetCategoryComment("Auxiliaries", "Temporal Auxiliary Moduls");
 	m_addBall[0] = GetConfig()->GetProperty("Auxiliaries", "PaperBall");

--- a/BMLMod.cpp
+++ b/BMLMod.cpp
@@ -1132,11 +1132,18 @@ void BMLMod::OnCmdEdit(CKDWORD key) {
 		else {
 			AddIngameMessage(m_cmdInput->GetText());
 		}
+		[[fallthrough]];
 	case CKKEY_ESCAPE:
 		m_cmdTyping = false;
-		InputHook::SetBlock(false);
 		m_cmdBar->SetVisible(false);
 		m_cmdInput->SetText("");
+		ModLoader::m_instance->AddTimerLoop(CKDWORD(1), [this, key] {
+			if (m_cmdTyping) return false;
+			if (ModLoader::m_instance->GetInputManager()->oIsKeyDown(key))
+				return true;
+			InputHook::SetBlock(false);
+			return false;
+		});
 		break;
 	case CKKEY_TAB:
 		if (m_cmdInput->GetText()[0] == '/') {

--- a/BMLMod.h
+++ b/BMLMod.h
@@ -147,6 +147,7 @@ private:
 class BMLMod : public IMod {
 	friend class CommandClear;
 	friend class CommandSector;
+	friend class CommandSpeed;
 	friend class GuiModMenu;
 	friend class GuiCustomMap;
 public:
@@ -255,7 +256,7 @@ private:
 	CKParameter* m_curTrafo;
 	CKDataArray* m_curLevel, * m_ingameParam;
 	int m_changeBallCd = 0;
-	IProperty* m_speedupBall;
+	IProperty* m_speedupBall, * m_speedNotification;
 	bool m_speedup;
 
 	IProperty* m_resetBall;

--- a/Commands.cpp
+++ b/Commands.cpp
@@ -120,7 +120,7 @@ void CommandSpeed::Execute(IBML* bml, const std::vector<std::string>& args) {
 				}
 			}
 
-			if (notify)
+			if (notify && ModLoader::m_instance->m_bmlmod->m_speedNotification->GetBoolean())
 				bml->SendIngameMessage(("Current Ball Speed Changed to " + std::to_string(time) + " times").c_str());
 		}
 	}

--- a/ModLoader.cpp
+++ b/ModLoader.cpp
@@ -379,7 +379,7 @@ void ModLoader::Process(CKERROR result) {
 	}
 
 	BroadcastCallback(&IMod::OnProcess, &IMod::OnProcess);
-	if (m_inputManager->IsKeyDown(CKKEY_F) && IsCheatEnabled())
+	if (IsCheatEnabled() && m_skipRenderKey && m_inputManager->IsKeyDown(m_skipRenderKey->GetKey()))
 		SkipRenderForNextTick();
 
 	m_inputManager->Process();

--- a/ModLoader.h
+++ b/ModLoader.h
@@ -32,6 +32,7 @@ class ModLoader : public IBML {
 	friend class CommandCheat;
 	friend class CommandClear;
 	friend class CommandSector;
+	friend class CommandSpeed;
 	friend class CommandWatermark;
 	friend class GuiList;
 	friend class GuiModOption;
@@ -234,6 +235,7 @@ private:
 
 	bool m_ingame = false, m_paused = false;
 	bool m_skipRender = false;
+	IProperty* m_skipRenderKey{};
 
 	std::map<void*, std::vector<IMod*>> m_callback_map;
 	void FillCallbackMap(IMod* mod);


### PR DESCRIPTION
Sorry but I can't really think of a better title to use.

## Fix

- **Keystroke fall-through**: keys that the player is holding are registered as normal key presses immediately after calling `InputHook::SetBlock(false)`. For example, if the player presses `Esc` to exit the command bar, then `Esc` events of whatever behind the bar is triggered too.
    * I was tempted to fix this directly in `InputHook` implementation but maybe this behavior is needed by some mods, so I only added a workaround with the command bar for compatibility reasons.
    * Actually we can also add another `SetBlockDefer(block, key, callback)` method (cf. [BallanceMMO # `set_input_block`](https://github.com/Swung0x48/BallanceMMO/blob/cce88cac73bc4b1553a95ea62f3f5f81955c5bf1/BallanceMMOClient/server_list.h#L176)) to solve this but it breaks the ABI :(

## Features

- **Config option to disable the speed change notification**: prevents the message/log spam when the player is constantly holding the `Ctrl` key to gain speed boosts.
- **Config option to change the skip render key**: ~~because why not~~ some players may need to use the `F` key for other uses other than skipping rendering.